### PR TITLE
Support services of type 'NodePort'.

### DIFF
--- a/extract-etcd-secrets.sh
+++ b/extract-etcd-secrets.sh
@@ -6,10 +6,10 @@ NAMESPACE="${NAMESPACE:-kube-system}"
 DIR="${OUTPUT:-config}"
 
 if [ -z "$CLUSTER_NAME" ]; then
-	CM_NAME=$(kubectl -n $NAMESPACE get cm cilium-config -o json | jq -r -c '.data."cluster-name"')
-	if [ "$CM_NAME" != "" -a "$CM_NAME" != "default" ]; then
+	CM_NAME=$(kubectl -n "$NAMESPACE" get cm cilium-config -o json | jq -r -c '.data."cluster-name"')
+	if [[ "$CM_NAME" != "" && "$CM_NAME" != "default" ]]; then
 		echo "Derived cluster-name $CM_NAME from present ConfigMap"
-		CLUSTER_NAME=$CM_NAME
+		CLUSTER_NAME="$CM_NAME"
 	else
 		echo "CLUSTER_NAME is not set"
 		echo "Set CLUSTER_NAME to the name of the cluster"
@@ -17,23 +17,23 @@ if [ -z "$CLUSTER_NAME" ]; then
 	fi
 fi
 
-mkdir -p $DIR
+mkdir -p "$DIR"
 
-SECRETS=$(kubectl -n $NAMESPACE get secret "cilium-etcd-secrets" -o json | jq -c '.data | to_entries[]')
+SECRETS=$(kubectl -n "$NAMESPACE" get secret "cilium-etcd-secrets" -o json | jq -c '.data | to_entries[]')
 for SECRET in $SECRETS; do
   KEY=$(echo "$SECRET" | jq -r '.key')
-  echo "$SECRET" | jq -r '.value' | base64 --decode > $DIR/$CLUSTER_NAME.$KEY
+  echo "$SECRET" | jq -r '.value' | base64 --decode > "$DIR/$CLUSTER_NAME.$KEY"
 done
 
 
-IPS=$(kubectl -n $NAMESPACE get svc cilium-etcd-external -o json | jq -r -c '.status.loadBalancer.ingress[0].ip')
-if [ -z "$IPS" -o $IPS = null ]; then
-	HOSTNAME=$(kubectl -n $NAMESPACE get svc cilium-etcd-external -o json | jq -r -c '.status.loadBalancer.ingress[0].hostname')
-	if [ -z "$HOSTNAME" -o $HOSTNAME = null ]; then
+IPS=$(kubectl -n "$NAMESPACE" get svc cilium-etcd-external -o json | jq -r -c '.status.loadBalancer.ingress[0].ip')
+if [ -z "$IPS" ] || [ "$IPS" = null ]; then
+	HOSTNAME=$(kubectl -n "$NAMESPACE" get svc cilium-etcd-external -o json | jq -r -c '.status.loadBalancer.ingress[0].hostname')
+	if [ -z "$HOSTNAME" ] || [ "$HOSTNAME" == null ]; then
 		echo "Unable to determine hostname for service cilium-etcd-external. .status.loadBalancer.ingress[0].hostname is empty"
 		exit 1
 	fi
-	IPS=$(host $HOSTNAME | grep address | awk '{print $NF}')
+	IPS=$(host "$HOSTNAME" | grep address | awk '{print $NF}')
 	if [ -z "$IPS" ]; then
 		echo "Unable to resolve hostname $HOSTNAME to IP"
 		exit 1
@@ -42,14 +42,14 @@ fi
 
 SERVICE_NAME="${CLUSTER_NAME}.mesh.cilium.io"
 
-cat > $DIR/$CLUSTER_NAME << EOF
+cat > "$DIR/$CLUSTER_NAME" << EOF
 endpoints:
 - https://${SERVICE_NAME}:2379
 EOF
 
-echo "$IPS"  > $DIR/${SERVICE_NAME}.ips
+echo "$IPS"  > "$DIR/${SERVICE_NAME}.ips"
 
-cat >> $DIR/$CLUSTER_NAME << EOF
+cat >> "$DIR/$CLUSTER_NAME" << EOF
 ca-file: '/var/lib/cilium/clustermesh/${CLUSTER_NAME}.etcd-client-ca.crt'
 key-file: '/var/lib/cilium/clustermesh/${CLUSTER_NAME}.etcd-client.key'
 cert-file: '/var/lib/cilium/clustermesh/${CLUSTER_NAME}.etcd-client.crt'

--- a/extract-etcd-secrets.sh
+++ b/extract-etcd-secrets.sh
@@ -3,6 +3,7 @@
 set -e
 
 NAMESPACE="${NAMESPACE:-kube-system}"
+SERVICE_NAME="${SERVICE_NAME:-cilium-etcd-external}"
 DIR="${OUTPUT:-config}"
 
 if [ -z "$CLUSTER_NAME" ]; then
@@ -25,26 +26,47 @@ for SECRET in $SECRETS; do
   echo "$SECRET" | jq -r '.value' | base64 --decode > "$DIR/$CLUSTER_NAME.$KEY"
 done
 
+SERVICE=$(kubectl -n "$NAMESPACE" get svc "$SERVICE_NAME" -o json)
+SERVICE_TYPE=$(echo "$SERVICE" | jq -r -c '.spec.type')
 
-IPS=$(kubectl -n "$NAMESPACE" get svc cilium-etcd-external -o json | jq -r -c '.status.loadBalancer.ingress[0].ip')
-if [ -z "$IPS" ] || [ "$IPS" = null ]; then
-	HOSTNAME=$(kubectl -n "$NAMESPACE" get svc cilium-etcd-external -o json | jq -r -c '.status.loadBalancer.ingress[0].hostname')
-	if [ -z "$HOSTNAME" ] || [ "$HOSTNAME" == null ]; then
-		echo "Unable to determine hostname for service cilium-etcd-external. .status.loadBalancer.ingress[0].hostname is empty"
-		exit 1
+case "$SERVICE_TYPE" in
+"NodePort")
+	# Grab the node's internal IPs.
+	IPS=$(kubectl -n "$NAMESPACE" get node \
+		-o jsonpath='{.items[*].status.addresses[?(@.type=="InternalIP")].address}' | tr ' ' '\n')
+	# Grab the node port on which etcd is exposed.
+	PORT=$(kubectl -n "$NAMESPACE" get svc "$SERVICE_NAME" \
+		-o jsonpath='{.spec.ports[?(@.port==2379)].nodePort}')
+	;;
+"LoadBalancer")
+	# Grab the load-balancer's IP(s).
+	IPS=$(echo "$SERVICE" | jq -r -c '.status.loadBalancer.ingress[0].ip')
+	if [ -z "$IPS" ] || [ "$IPS" = null ]; then
+		HOSTNAME=$(echo "$SERVICE" | jq -r -c '.status.loadBalancer.ingress[0].hostname')
+		if [ -z "$HOSTNAME" ] || [ "$HOSTNAME" == null ]; then
+			echo "Unable to determine hostname for service $SERVICE_NAME. .status.loadBalancer.ingress[0].hostname is empty"
+			exit 1
+		fi
+		IPS=$(host "$HOSTNAME" | grep address | awk '{print $NF}')
+		if [ -z "$IPS" ]; then
+			echo "Unable to resolve hostname $HOSTNAME to IP"
+			exit 1
+		fi
 	fi
-	IPS=$(host "$HOSTNAME" | grep address | awk '{print $NF}')
-	if [ -z "$IPS" ]; then
-		echo "Unable to resolve hostname $HOSTNAME to IP"
-		exit 1
-	fi
-fi
+	# Use '2379' as the port, as that's what load-balancers will be using.
+	PORT="2379"
+	;;
+*)
+	echo "Services of type $SERVICE_TYPE are not supported. Please use NodePort or LoadBalancer."
+	exit 1
+	;;
+esac
 
 SERVICE_NAME="${CLUSTER_NAME}.mesh.cilium.io"
 
 cat > "$DIR/$CLUSTER_NAME" << EOF
 endpoints:
-- https://${SERVICE_NAME}:2379
+- https://${SERVICE_NAME}:${PORT}
 EOF
 
 echo "$IPS"  > "$DIR/${SERVICE_NAME}.ips"

--- a/generate-name-mapping.sh
+++ b/generate-name-mapping.sh
@@ -11,10 +11,11 @@ spec:
       hostAliases:
 EOF
 
-for IPFILE in $DIR/*.ips; do
-	for IP in $(cat $IPFILE); do
+for IPFILE in "$DIR"/*.ips; do
+	HOSTNAME=$(basename "$IPFILE")
+	while read -r IP; do
 		echo "      - ip: \"$IP\""
 		echo "        hostnames:"
-		echo "        - $(basename $IPFILE | sed -e s/.ips$//)"
-	done
+		echo "        - ${HOSTNAME/.ips/}"
+	done < "$IPFILE"
 done

--- a/generate-secret-yaml.sh
+++ b/generate-secret-yaml.sh
@@ -4,10 +4,8 @@ set -e
 
 DIR="${OUTPUT:-config}"
 
-for SECRET in $DIR/*; do
+for SECRET in "$DIR"/*; do
 	if [[ ! "$SECRET" =~ .ips$ ]]; then
-		ARGS="$ARGS --from-file=$SECRET"
+		echo "--from-file=$SECRET"
 	fi
-done
-
-kubectl create --dry-run=true secret generic cilium-clustermesh $ARGS -o yaml
+done | xargs kubectl create --dry-run=true secret generic cilium-clustermesh -o yaml


### PR DESCRIPTION
This PR adds support for exposing each cluster's `etcd` via a service of type `NodePort`. The existing support for services of type `LoadBalancer` is left mostly untouched. I also took some time to make `shellcheck` happy, but please let me know if this is undesirable (I understand it makes reviewing a bit harder than it could be). https://github.com/cilium/cilium/pull/9725 updates the documentation accordingly.