### PR TITLE
Improved support for non etcd-managed clusters

### DIFF
--- a/generate-name-mapping.sh
+++ b/generate-name-mapping.sh
@@ -4,6 +4,8 @@ set -e
 
 DIR="${OUTPUT:-config}"
 
+ls ${DIR}/*.ips &> /dev/null || exit 0
+
 cat << EOF
 spec:
   template:

--- a/generate-secret-yaml.sh
+++ b/generate-secret-yaml.sh
@@ -3,6 +3,9 @@
 set -e
 
 DIR="${OUTPUT:-config}"
+KUBECONFIG="${KUBECONFIG:+--kubeconfig=${KUBECONFIG}}"
+
+kubectl="kubectl $KUBECONFIG"
 
 for SECRET in "$DIR"/*; do
 	if [[ ! "$SECRET" =~ .ips$ ]]; then


### PR DESCRIPTION
I was trying this on a non etcd-managed cluster and came up with these changes to increase the chances that the scripts work on such environments. Changes include:

* Allow setting a kubeconfig, useful when working with different clusters.
* Reuse the existing etcd endpoint config if the ips are addressable from other clusters, avoiding dependency on mesh.cilium.io subdomain.
* Reuse the existing etcd key/cert config avoiding any assumption on the names of the files.

Throwing it out here in case it could be useful. Willing to work on it if it could be improved a bit, but limited in the amount of scenarios I can try this out.