### PR TITLE
generate-secret-yaml.sh: Fix a warning about --dry-run=true

### DIFF
--- a/generate-secret-yaml.sh
+++ b/generate-secret-yaml.sh
@@ -5,10 +5,19 @@ set -e
 DIR="${OUTPUT:-config}"
 KUBECONFIG="${KUBECONFIG:+--kubeconfig=${KUBECONFIG}}"
 
+# NOTE: --dry-run=true is deprecated starting kubectl v1.18 and
+# --dry-run=client should be used instead.
+DRYRUN=true
+MAJOR=$(kubectl version -o json | jq -r '.clientVersion.major')
+MINOR=$(kubectl version -o json | jq -r '.clientVersion.minor')
+if [ $MAJOR -gt 1 ] || [ $MAJOR -eq 1 -a $MINOR -ge 18 ]; then
+    DRYRUN=client
+fi
+
 kubectl="kubectl $KUBECONFIG"
 
 for SECRET in "$DIR"/*; do
 	if [[ ! "$SECRET" =~ .ips$ ]]; then
 		echo "--from-file=$SECRET"
 	fi
-done | xargs kubectl create --dry-run=true secret generic cilium-clustermesh -o yaml
+done | xargs kubectl create --dry-run=$DRYRUN secret generic cilium-clustermesh -o yaml


### PR DESCRIPTION
Before this patch, we get:

    ./generate-secret-yaml.sh > clustermesh.yaml
    W0918 15:47:34.887968   76994 helpers.go:549] --dry-run=true is deprecated (boolean value) and can be replaced with --dry-run=client.

Fix #3 